### PR TITLE
Fixes broken pipe error due to closed client socket

### DIFF
--- a/src/Master.php
+++ b/src/Master.php
@@ -76,7 +76,13 @@ final class Master
         Logger::log('master', posix_getpid(), 'write to ' . (int)$client, $data);
 
         yield Dispatcher::listenWrite($client);
-        fwrite($client, $data);
+        
+        //Check if connection is writable. This is causing the Broken pipe error 
+        $meta = stream_get_meta_data($client); 
+ 
+        if(isset($meta['uri']) && is_writable($meta['uri'])) { 
+            fwrite($client, $data); 
+        } 
     }
 
     /**


### PR DESCRIPTION
The broken pipe error occurs when master tries to write to a closed client socket. Browsers closes connections automatically when the idle to long or users switch tabs for example. Therefor we need to check if the client is still connected and his socket is writable.